### PR TITLE
ci: adjust baseUrl for production

### DIFF
--- a/env/.env.prod
+++ b/env/.env.prod
@@ -1,3 +1,3 @@
 TITLE="Horizen Academy"
 URL="https://main.horizen-academy-v2.pages.dev/"
-BASE_URL="/"
+BASE_URL="/academy/"


### PR DESCRIPTION
We are using /academy/ on production because we are going to "inject" the project under horizen.io/academy